### PR TITLE
Handle download errors

### DIFF
--- a/data/data_fetcher.py
+++ b/data/data_fetcher.py
@@ -9,6 +9,23 @@ from datetime import datetime
 _data_cache = {}
 
 
+def _safe_download(ticker: str, start: str) -> pd.DataFrame:
+    """Attempt to download price data with a fallback."""
+    try:
+        df = yf.download(ticker, start=start, progress=False, show_errors=False)
+    except Exception as e:
+        print(f"[WARNING] yf.download failed for {ticker}: {e}")
+        df = pd.DataFrame()
+
+    if df.empty:
+        try:
+            df = yf.Ticker(ticker).history(start=start)
+        except Exception as e:
+            print(f"[ERROR] history() failed for {ticker}: {e}")
+            df = pd.DataFrame()
+    return df
+
+
 def load_historical_data(ticker: str, start_date="1980-01-01", local_data_dir="data/local_csv") -> pd.DataFrame:
     """
     Load historical data for 'ticker' from a local CSV if available;
@@ -37,34 +54,55 @@ def load_historical_data(ticker: str, start_date="1980-01-01", local_data_dir="d
 
     if os.path.exists(local_csv_path):
         print(f"[LOCAL CSV] Loading {ticker} from {local_csv_path}")
-        # Open the file and check the first line.
+        # Inspect the first line so we can determine how to read the file.
         with open(local_csv_path, 'r') as f:
-            first_line = f.readline()
+            first_line = f.readline().strip()
 
-        # If the first line contains "Date", assume the CSV has a header.
         if "Date" in first_line:
+            # Standard CSV with a header row
             df = pd.read_csv(
                 local_csv_path,
                 parse_dates=["Date"],
-                index_col="Date"
+                index_col="Date",
+            )
+        elif first_line.startswith("Price"):
+            # Custom exported format. The first three lines contain
+            # column labels like "Price"/"Ticker"/"Date". Determine how
+            # many actual columns are present so we can construct the
+            # appropriate list of names.
+            column_count = len(first_line.split(','))
+            if column_count >= 6:
+                names = ["Date", "Close", "High", "Low", "Open", "Volume"]
+            else:
+                # Some files only contain a date and closing price
+                names = ["Date", "Close"]
+            df = pd.read_csv(
+                local_csv_path,
+                skiprows=3,
+                header=None,
+                names=names,
+                usecols=range(len(names)),
+                parse_dates=["Date"],
+                index_col="Date",
             )
         else:
-            # Otherwise, use the old method (skip first 3 rows, no header in the remaining data).
+            # Fallback to the old behaviour of skipping three rows
             df = pd.read_csv(
                 local_csv_path,
                 skiprows=3,
                 header=None,
                 names=["Date", "Close", "High", "Low", "Open", "Volume"],
                 parse_dates=["Date"],
-                index_col="Date"
+                index_col="Date",
             )
-        df.dropna(inplace=True)
+
+        df.dropna(subset=["Close"], inplace=True)
         df.sort_index(inplace=True)
 
         # If CSV is empty, re-download data.
         if df.empty:
             print(f"[WARNING] CSV for {ticker} is empty. Downloading fresh data from Yahoo Finance.")
-            df = yf.download(ticker, start=start_date, progress=False)
+            df = _safe_download(ticker, start_date)
             if not df.empty:
                 df.to_csv(local_csv_path)
                 df = df[['Close']].copy()
@@ -78,7 +116,7 @@ def load_historical_data(ticker: str, start_date="1980-01-01", local_data_dir="d
             today_str = datetime.today().strftime('%Y-%m-%d')
             if new_start_date < today_str:
                 print(f"[UPDATE] Checking for new data for {ticker} from {new_start_date} to {today_str}")
-                new_df = yf.download(ticker, start=new_start_date, progress=False)
+                new_df = _safe_download(ticker, new_start_date)
                 if not new_df.empty:
                     new_df = new_df[['Close']].copy()
                     new_df.dropna(inplace=True)
@@ -92,7 +130,7 @@ def load_historical_data(ticker: str, start_date="1980-01-01", local_data_dir="d
                     print(f"[UPDATE] No new data available for {ticker} after {last_date.date()}.")
     else:
         print(f"[YAHOO] Downloading {ticker} from {start_date}")
-        df = yf.download(ticker, start=start_date, progress=False)
+        df = _safe_download(ticker, start_date)
         if not df.empty:
             df.to_csv(local_csv_path)
 


### PR DESCRIPTION
## Summary
- catch yfinance errors when updating data
- suppress library error messages using `show_errors=False`
- add retry mechanism using `Ticker.history` when `download` fails

## Testing
- `python -m py_compile run_optimization.py data/data_fetcher.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685223bfd4a0832cadf4be3cc43df025