### PR TITLE
Fix data download races

### DIFF
--- a/data/data_fetcher.py
+++ b/data/data_fetcher.py
@@ -73,6 +73,11 @@ def load_historical_data(ticker: str, start_date="1980-01-01", local_data_dir="d
 
     lock_path = f"{local_csv_path}.lock"
     with FileLock(lock_path):
+        # Re-check cache after acquiring the lock in case another thread
+        # loaded the data while we were waiting.
+        if ticker in _data_cache:
+            print(f"[CACHE HIT] {ticker} in-memory (after lock).")
+            return _data_cache[ticker]
         if os.path.exists(local_csv_path):
             print(f"[LOCAL CSV] Loading {ticker} from {local_csv_path}")
             # Inspect the first line so we can determine how to read the file.


### PR DESCRIPTION
## Summary
- ensure historical data cache is rechecked after acquiring the file lock

## Testing
- `pip install pandas yfinance matplotlib tqdm filelock` *(fails: Tunnel connection failed)*
- `python main.py config/configD.txt test_out 1` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6852e81bec1c832c8ed1019197d9f08a