### PR TITLE
Add expense ratio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ strategies.  Example:
 python -m stock_market_simulator.main config/configA.txt my_report
 ```
 
+Each `ticker=` line can optionally include `spread` (bid/ask percentage) and
+`expense_ratio` (annual fee percentage).  The expense ratio is deducted daily
+during simulation.
+
 Results are written to `reports/my_report/` including plots and a `report.txt`
 with detailed statistics.
 

--- a/config/configA.txt
+++ b/config/configA.txt
@@ -5,32 +5,32 @@ years=5
 stepsize=1
 
 approach=S&P500_buyhold
-    ticker=^GSPC, strategy=buy_hold, spread=0.05
+    ticker=^GSPC, strategy=buy_hold, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_SMA_Trading
-    ticker=^GSPC, strategy=sma_trading, spread=0.05
+    ticker=^GSPC, strategy=sma_trading, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_adv_daytrading
-    ticker=^GSPC, strategy=advanced_daytrading, spread=0.05
+    ticker=^GSPC, strategy=advanced_daytrading, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_RSI
-    ticker=^GSPC, strategy=rsi, spread=0.05
+    ticker=^GSPC, strategy=rsi, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_Momentum_Breakout
-    ticker=^GSPC, strategy=momentum_breakout, spread=0.05
+    ticker=^GSPC, strategy=momentum_breakout, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_buyhold
-    ticker=^IXIC, strategy=buy_hold, spread=0.05
+    ticker=^IXIC, strategy=buy_hold, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_SMA_Trading
-    ticker=^IXIC, strategy=sma_trading, spread=0.05
+    ticker=^IXIC, strategy=sma_trading, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_adv_daytrading
-    ticker=^IXIC, strategy=advanced_daytrading, spread=0.05
+    ticker=^IXIC, strategy=advanced_daytrading, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_RSI
-    ticker=^IXIC, strategy=rsi, spread=0.05
+    ticker=^IXIC, strategy=rsi, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_Momentum_Breakout
-    ticker=^IXIC, strategy=momentum_breakout, spread=0.05
+    ticker=^IXIC, strategy=momentum_breakout, spread=0.05, expense_ratio=0.1
 

--- a/config/configB.txt
+++ b/config/configB.txt
@@ -5,32 +5,32 @@ years=10
 stepsize=1
 
 approach=S&P500_buyhold
-    ticker=^GSPC, strategy=buy_hold, spread=0.05
+    ticker=^GSPC, strategy=buy_hold, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_SMA_Trading
-    ticker=^GSPC, strategy=sma_trading, spread=0.05
+    ticker=^GSPC, strategy=sma_trading, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_adv_daytrading
-    ticker=^GSPC, strategy=advanced_daytrading, spread=0.05
+    ticker=^GSPC, strategy=advanced_daytrading, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_RSI
-    ticker=^GSPC, strategy=rsi, spread=0.05
+    ticker=^GSPC, strategy=rsi, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_Momentum_Breakout
-    ticker=^GSPC, strategy=momentum_breakout, spread=0.05
+    ticker=^GSPC, strategy=momentum_breakout, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_buyhold
-    ticker=^IXIC, strategy=buy_hold, spread=0.05
+    ticker=^IXIC, strategy=buy_hold, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_SMA_Trading
-    ticker=^IXIC, strategy=sma_trading, spread=0.05
+    ticker=^IXIC, strategy=sma_trading, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_adv_daytrading
-    ticker=^IXIC, strategy=advanced_daytrading, spread=0.05
+    ticker=^IXIC, strategy=advanced_daytrading, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_RSI
-    ticker=^IXIC, strategy=rsi, spread=0.05
+    ticker=^IXIC, strategy=rsi, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_Momentum_Breakout
-    ticker=^IXIC, strategy=momentum_breakout, spread=0.05
+    ticker=^IXIC, strategy=momentum_breakout, spread=0.05, expense_ratio=0.1
 

--- a/config/configC.txt
+++ b/config/configC.txt
@@ -5,32 +5,32 @@ years=15
 stepsize=1
 
 approach=S&P500_buyhold
-    ticker=^GSPC, strategy=buy_hold, spread=0.05
+    ticker=^GSPC, strategy=buy_hold, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_SMA_Trading
-    ticker=^GSPC, strategy=sma_trading, spread=0.05
+    ticker=^GSPC, strategy=sma_trading, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_adv_daytrading
-    ticker=^GSPC, strategy=advanced_daytrading, spread=0.05
+    ticker=^GSPC, strategy=advanced_daytrading, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_RSI
-    ticker=^GSPC, strategy=rsi, spread=0.05
+    ticker=^GSPC, strategy=rsi, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_Momentum_Breakout
-    ticker=^GSPC, strategy=momentum_breakout, spread=0.05
+    ticker=^GSPC, strategy=momentum_breakout, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_buyhold
-    ticker=^IXIC, strategy=buy_hold, spread=0.05
+    ticker=^IXIC, strategy=buy_hold, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_SMA_Trading
-    ticker=^IXIC, strategy=sma_trading, spread=0.05
+    ticker=^IXIC, strategy=sma_trading, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_adv_daytrading
-    ticker=^IXIC, strategy=advanced_daytrading, spread=0.05
+    ticker=^IXIC, strategy=advanced_daytrading, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_RSI
-    ticker=^IXIC, strategy=rsi, spread=0.05
+    ticker=^IXIC, strategy=rsi, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_Momentum_Breakout
-    ticker=^IXIC, strategy=momentum_breakout, spread=0.05
+    ticker=^IXIC, strategy=momentum_breakout, spread=0.05, expense_ratio=0.1
 

--- a/config/configD.txt
+++ b/config/configD.txt
@@ -5,32 +5,32 @@ years=20
 stepsize=1
 
 approach=S&P500_buyhold
-    ticker=^GSPC, strategy=buy_hold, spread=0.05
+    ticker=^GSPC, strategy=buy_hold, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_SMA_Trading
-    ticker=^GSPC, strategy=sma_trading, spread=0.05
+    ticker=^GSPC, strategy=sma_trading, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_adv_daytrading
-    ticker=^GSPC, strategy=advanced_daytrading, spread=0.05
+    ticker=^GSPC, strategy=advanced_daytrading, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_RSI
-    ticker=^GSPC, strategy=rsi, spread=0.05
+    ticker=^GSPC, strategy=rsi, spread=0.05, expense_ratio=0.1
 
 approach=S&P500_Momentum_Breakout
-    ticker=^GSPC, strategy=momentum_breakout, spread=0.05
+    ticker=^GSPC, strategy=momentum_breakout, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_buyhold
-    ticker=^IXIC, strategy=buy_hold, spread=0.05
+    ticker=^IXIC, strategy=buy_hold, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_SMA_Trading
-    ticker=^IXIC, strategy=sma_trading, spread=0.05
+    ticker=^IXIC, strategy=sma_trading, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_adv_daytrading
-    ticker=^IXIC, strategy=advanced_daytrading, spread=0.05
+    ticker=^IXIC, strategy=advanced_daytrading, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_RSI
-    ticker=^IXIC, strategy=rsi, spread=0.05
+    ticker=^IXIC, strategy=rsi, spread=0.05, expense_ratio=0.1
 
 approach=NASDAQ_Momentum_Breakout
-    ticker=^IXIC, strategy=momentum_breakout, spread=0.05
+    ticker=^IXIC, strategy=momentum_breakout, spread=0.05, expense_ratio=0.1
 

--- a/simulation/simulator.py
+++ b/simulation/simulator.py
@@ -21,6 +21,8 @@ class HybridMultiFundPortfolio:
             pf = Portfolio(sub_cash)
             # Set the fixed bid/ask spread for this ticker.
             pf.spread = ticker_info_dict[tkSym].get("spread", 0.0)
+            # Optional yearly expense ratio percentage.
+            pf.expense_ratio = ticker_info_dict[tkSym].get("expense_ratio", 0.0)
             # If strategy is advanced_daytrading, attach advanced parameters (if provided) to the portfolio.
             if ticker_info_dict[tkSym]["strategy"].__name__ == "advanced_daytrading":
                 advanced_params = {}
@@ -70,6 +72,9 @@ def run_hybrid_multi_fund(dfs_dict, hybrid_pf: HybridMultiFundPortfolio):
             execute_orders(cur_price, pf, day_i)
             strategy_func = hybrid_pf.strategies_for_tickers[sym]
             strategy_func(pf, dt, cur_price, day_i)
+            # Deduct daily expense ratio fee
+            daily_fee = pf.total_value(cur_price) * (pf.expense_ratio / 100.0) / 365.0
+            pf.cash -= daily_fee
 
         tv = hybrid_pf.total_value(day_prices)
         pct = ((tv - hybrid_pf.initial_cash) / hybrid_pf.initial_cash) * 100

--- a/utils/config_parser.py
+++ b/utils/config_parser.py
@@ -16,11 +16,14 @@ def parse_config_file(config_path):
     Returns: (years, stepsize, approaches)
       where approaches = [(approach_name, {ticker: {
           "strategy": strategy_func,
-          "spread": spread_value (as a percentage)
+          "spread": spread_value (as a percentage),
+          "expense_ratio": optional yearly expense ratio (%)
       } }), ...]
 
-    Note: The optional 'spread' parameter is now interpreted as a percentage.
-          For example, spread=1 means a 1% bid/ask spread.
+    Note: The optional 'spread' parameter is interpreted as a percentage.
+          For example, spread=1 means a 1% bid/ask spread.  Another optional
+          parameter is 'expense_ratio', representing an annual management fee
+          percentage that will be deducted daily from the portfolio.
     """
     years = None
     stepsize = None
@@ -75,20 +78,27 @@ def parse_config_file(config_path):
                     print(f"Warning: unknown strategy '{strategy_str}' => {line_strip}")
                     continue
 
-                # New: Check for an optional spread parameter (interpreted as a percentage)
-                spread_val = 0.0  # default spread is 0%
+                # Optional parameters for this ticker line
+                spread_val = 0.0      # bid/ask spread percent
+                expense_ratio_val = 0.0  # yearly expense ratio percent
                 for sp in parts[1:]:
-                    if sp.lower().startswith("spread="):
+                    low = sp.lower()
+                    if low.startswith("spread="):
                         try:
                             spread_val = float(sp[len("spread="):].strip())
                         except ValueError:
                             print(f"Warning: invalid spread value in line => {line_strip}")
-                        break
+                    elif low.startswith("expense_ratio="):
+                        try:
+                            expense_ratio_val = float(sp[len("expense_ratio="):].strip())
+                        except ValueError:
+                            print(f"Warning: invalid expense_ratio in line => {line_strip}")
 
-                # Map the ticker to a dict with keys "strategy" and "spread".
+                # Map the ticker to a dict with strategy, spread, and expense_ratio
                 current_ticker_dict[ticker_str] = {
                     "strategy": STRATEGY_MAP[strategy_str],
-                    "spread": spread_val
+                    "spread": spread_val,
+                    "expense_ratio": expense_ratio_val,
                 }
 
             # maybe years=5 or stepsize=1


### PR DESCRIPTION
## Summary
- parse optional `expense_ratio` in config parser
- add expense ratio field to portfolio creation
- subtract daily expense fee during simulation
- document new parameter in README
- update example configs with sample `expense_ratio` values

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68531829a34c832cac7312c5397106ca