### PR TITLE
Add optimization PDF reporting

### DIFF
--- a/optimization/report_pdf.py
+++ b/optimization/report_pdf.py
@@ -1,0 +1,67 @@
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+
+
+def _plot_heatmap(pivot_df, title, pdf):
+    fig, ax = plt.subplots()
+    im = ax.imshow(pivot_df.values, cmap="viridis", aspect="auto", origin="lower")
+    ax.set_xticks(range(len(pivot_df.columns)))
+    ax.set_xticklabels(pivot_df.columns)
+    ax.set_yticks(range(len(pivot_df.index)))
+    ax.set_yticklabels(pivot_df.index)
+    for i in range(pivot_df.shape[0]):
+        for j in range(pivot_df.shape[1]):
+            val = pivot_df.values[i, j]
+            if pd.notna(val):
+                ax.text(j, i, f"{val:.1f}", ha="center", va="center", color="w", fontsize=6)
+    ax.set_xlabel("Limit Discount %")
+    ax.set_ylabel("Trailing Stop %")
+    ax.set_title(title)
+    fig.colorbar(im, ax=ax, label="Metric")
+    plt.tight_layout()
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def create_pdf_report(best_by_year, output_dir):
+    """Create a PDF summary report for optimization results."""
+    os.makedirs(output_dir, exist_ok=True)
+    pdf_path = os.path.join(output_dir, "optimization_summary.pdf")
+    with PdfPages(pdf_path) as pdf:
+        for years_val, (best_params, best_avg, group_dict) in sorted(best_by_year.items()):
+            # Text summary page
+            fig, ax = plt.subplots(figsize=(8, 3))
+            ax.axis("off")
+            text = (
+                f"Window: {years_val} years\n"
+                f"Best Parameters: TS={best_params[0]}%, "
+                f"LD={best_params[1]}%, PLD={best_params[2]}\n"
+                f"Average Metric: {best_avg:.2f}%"
+            )
+            ax.text(0.05, 0.5, text, fontsize=12, va="center")
+            pdf.savefig(fig)
+            plt.close(fig)
+
+            # Boxplot of all metrics for this year window
+            metrics = list(group_dict.values())
+            fig, ax = plt.subplots()
+            ax.boxplot(metrics)
+            ax.set_title(f"Metric Distribution - {years_val}y")
+            ax.set_ylabel("Metric")
+            pdf.savefig(fig)
+            plt.close(fig)
+
+            # Heatmaps per pending_limit_days
+            df = pd.DataFrame([
+                (ts, lb, pl, metric)
+                for (ts, lb, pl), metric in group_dict.items()
+            ], columns=["TS", "LD", "PL", "Metric"])
+            for pl_val in sorted(df["PL"].unique()):
+                pivot = df[df["PL"] == pl_val].pivot(index="TS", columns="LD", values="Metric")
+                pivot = pivot.sort_index().sort_index(axis=1)
+                _plot_heatmap(pivot, f"{years_val}y - Pending {pl_val} days", pdf)
+
+    print(f"PDF report saved to {pdf_path}")
+    return pdf_path

--- a/run_optimization.py
+++ b/run_optimization.py
@@ -1,12 +1,27 @@
 # run_optimization.py
 
+import os
+import sys
 import pandas as pd
-from stock_market_simulator.data.data_fetcher import load_historical_data
-from stock_market_simulator.strategies.base_strategies import STRATEGY_MAP
-from stock_market_simulator.optimization.parameter_sweeper import optimize_full_advanced_daytrading, metric_cagr, metric_lowest_valley
 import multiprocessing
 
+from stock_market_simulator.data.data_fetcher import load_historical_data
+from stock_market_simulator.strategies.base_strategies import STRATEGY_MAP
+from stock_market_simulator.optimization.parameter_sweeper import (
+    optimize_full_advanced_daytrading,
+    metric_cagr,
+)
+from stock_market_simulator.optimization.report_pdf import create_pdf_report
+
 def main():
+    """Run optimization sweep and generate a PDF summary."""
+    output_name = "optimization_output"
+    if len(sys.argv) >= 2:
+        output_name = sys.argv[1]
+
+    out_dir = os.path.join("reports", output_name)
+    os.makedirs(out_dir, exist_ok=True)
+
     # Specify the ticker and load historical data.
     ticker = "^IXIC"  # or any ticker using the advanced_daytrading strategy
     df = load_historical_data(ticker)
@@ -47,6 +62,9 @@ def main():
         # print("  All group results:")
         # for params, avg_metric in all_groups.items():
         #     print(f"    {params}: {avg_metric:.2f}%")
+
+    # Generate PDF summary report
+    create_pdf_report(best_by_year, out_dir)
 
 if __name__ == '__main__':
     multiprocessing.freeze_support()


### PR DESCRIPTION
## Summary
- add PDF report generation for parameter sweeps
- save optimization summary PDF in `reports/<name>`
- call PDF report generator from optimization runner

## Testing
- `python -m py_compile run_optimization.py optimization/report_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_68545ed50670832c80f03e3fd13254e1