### PR TITLE
Add automatic PDF reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ locally so repeated runs are fast.
   trading parameters to find combinations with the best performance metric.
 - **GUI** – a Tkinter interface in `gui/visualizer.py` lets you run simulations
   interactively and view the resulting equity curves.
+- **Automatic PDF summaries** – results folders include a single PDF combining
+  the config, console log and all generated plots.
 
 ## Requirements
 Install the Python dependencies via:
@@ -24,7 +26,7 @@ Install the Python dependencies via:
 pip install -r requirements.txt
 ```
 
-The simulator relies on `pandas`, `yfinance` and `matplotlib`.
+The simulator relies on `pandas`, `yfinance`, `matplotlib` and `fpdf`.
 
 ## Usage
 ### Running a sweep
@@ -39,8 +41,8 @@ Each `ticker=` line can optionally include `spread` (bid/ask percentage) and
 `expense_ratio` (annual fee percentage).  The expense ratio is deducted daily
 during simulation.
 
-Results are written to `reports/my_report/` including plots and a `report.txt`
-with detailed statistics.
+Results are written to `reports/my_report/` including plots, a `report.txt`
+with detailed statistics and a consolidated `report.pdf`.
 
 ### GUI
 To explore strategies interactively, launch the visualizer:

--- a/main.py
+++ b/main.py
@@ -256,5 +256,11 @@ def main():
 
         buffer.close()
 
+        try:
+            from stock_market_simulator.utils.pdf_report import create_pdf_report
+            create_pdf_report(out_dir)
+        except Exception as e:
+            print(f"Failed to create PDF report: {e}")
+
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,7 @@ matplotlib>=3.0
 tqdm>=4.0
 # File locking for safe concurrent CSV updates
 filelock>=3.0
+# PDF generation
+fpdf>=1.0
 # Add any others you might need, e.g.:
 # numpy>=1.17

--- a/utils/pdf_report.py
+++ b/utils/pdf_report.py
@@ -1,0 +1,39 @@
+import os
+import glob
+from fpdf import FPDF
+
+
+def create_pdf_report(out_dir):
+    """Generate a PDF summary inside *out_dir*.
+
+    The function reads ``config.txt`` and ``report.txt`` from the directory and
+    appends all ``*.png`` plots. The resulting file is saved as ``report.pdf``.
+    """
+    config_path = os.path.join(out_dir, "config.txt")
+    report_path = os.path.join(out_dir, "report.txt")
+    pdf_path = os.path.join(out_dir, "report.pdf")
+
+    pdf = FPDF()
+    pdf.set_auto_page_break(auto=True, margin=15)
+
+    if os.path.exists(config_path):
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        with open(config_path, "r") as cfg:
+            for line in cfg:
+                pdf.multi_cell(0, 10, line.rstrip())
+
+    if os.path.exists(report_path):
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        with open(report_path, "r") as rep:
+            for line in rep:
+                pdf.multi_cell(0, 10, line.rstrip())
+
+    for img_path in sorted(glob.glob(os.path.join(out_dir, "*.png"))):
+        pdf.add_page()
+        # Leave a small margin around the image
+        pdf.image(img_path, x=10, y=10, w=pdf.w - 20)
+
+    pdf.output(pdf_path)
+    return pdf_path


### PR DESCRIPTION
## Summary
- add fpdf to requirements
- create utils/pdf_report module for consolidating run output into a single PDF
- generate PDF after each simulation run
- document PDF creation in README

## Testing
- `python -m stock_market_simulator.batch_runner` *(fails: ModuleNotFoundError for matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_6854608cc804832cac2f0852e69e6ac0