### PR TITLE
Add cache cleanup utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,14 @@ Date,Open,High,Low,Close,Volume
 
 See `data/CSV_FORMAT.md` for details.  If legacy files exist, use the
 conversion script from the previous task or remove them to trigger fresh
-downloads.
+downloads.  You can also run the cleanup helper:
+
+```bash
+python utils/cleanup_cache.py
+```
+
+Mismatching files are renamed with a `.bad` extension.  Pass `--delete`
+to remove them instead.
 
 ## License
 This project is provided for educational purposes and comes with no warranty.

--- a/utils/cleanup_cache.py
+++ b/utils/cleanup_cache.py
@@ -1,0 +1,61 @@
+"""Utility for removing stale cached CSV files.
+
+This script checks files under ``data/local_csv`` and ``gui/data/local_csv``.
+If a file's header line does not exactly match::
+
+    Date,Open,High,Low,Close,Volume
+
+it will be renamed with a ``.bad`` extension or deleted when ``--delete`` is
+supplied.
+"""
+
+import argparse
+import csv
+import os
+from typing import Iterable
+
+EXPECTED_HEADER = ["Date", "Open", "High", "Low", "Close", "Volume"]
+
+
+def _process_dir(directory: str, delete: bool) -> None:
+    if not os.path.isdir(directory):
+        return
+    for fname in os.listdir(directory):
+        if not fname.endswith(".csv"):
+            continue
+        path = os.path.join(directory, fname)
+        try:
+            with open(path, newline="") as f:
+                reader = csv.reader(f)
+                header = next(reader, [])
+        except Exception as e:
+            print(f"[ERROR] Could not read {path}: {e}")
+            continue
+
+        if header != EXPECTED_HEADER:
+            if delete:
+                os.remove(path)
+                print(f"[DELETE] {path}")
+            else:
+                new_path = path + ".bad"
+                os.rename(path, new_path)
+                print(f"[RENAME] {path} -> {new_path}")
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Remove or rename cached CSVs with unexpected headers"
+    )
+    parser.add_argument(
+        "--delete",
+        action="store_true",
+        help="Delete bad files instead of renaming with .bad",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    for directory in ("data/local_csv", "gui/data/local_csv"):
+        _process_dir(directory, delete=args.delete)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add utility script to rename/delete cached CSVs with unexpected headers
- document cleanup_cache.py usage in README

## Testing
- `python utils/cleanup_cache.py --help`
- `python -m py_compile utils/cleanup_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_68597abec5e4832c9e07589ffd655dea