### PR TITLE
Add execution order tests

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,72 @@
+import os
+import sys
+import types
+import pytest
+
+# Add repo root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Create alias package so modules using the full name work
+if "stock_market_simulator" not in sys.modules:
+    pkg = types.ModuleType("stock_market_simulator")
+    pkg.__path__ = [os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))]
+    sys.modules["stock_market_simulator"] = pkg
+
+import simulation
+sys.modules["stock_market_simulator.simulation"] = simulation
+import simulation.portfolio as pf_module
+sys.modules["stock_market_simulator.simulation.portfolio"] = pf_module
+
+from simulation.portfolio import Portfolio, Order
+from simulation.execution import execute_orders
+
+
+def test_execute_orders_market_limit_trailing():
+    pf = Portfolio(initial_cash=1000.0)
+    # Market buy entire balance at price 10
+    pf.orders.append(Order(side="buy", order_type="market"))
+    execute_orders(10.0, pf, 0)
+    assert pf.shares == pytest.approx(100.0)
+    assert pf.cash == pytest.approx(0.0)
+    assert pf.orders == []
+
+    # Limit sell - should not trigger at price below limit
+    limit = Order(side="sell", order_type="limit", limit_price=15.0)
+    pf.orders.append(limit)
+    execute_orders(14.0, pf, 1)
+    assert pf.shares == pytest.approx(100.0)
+    assert pf.cash == pytest.approx(0.0)
+    assert limit in pf.orders
+
+    # Price hits limit, sell all shares
+    execute_orders(16.0, pf, 2)
+    assert pf.shares == pytest.approx(0.0)
+    assert pf.cash == pytest.approx(1600.0)
+    assert pf.orders == []
+
+    # Buy again with market order at price 16
+    pf.orders.append(Order(side="buy", order_type="market"))
+    execute_orders(16.0, pf, 3)
+    assert pf.shares == pytest.approx(100.0)
+    assert pf.cash == pytest.approx(0.0)
+    assert pf.orders == []
+
+    # Trailing stop of 10%
+    ts_order = Order(side="sell", order_type="trailing_stop", trail_percent=10.0)
+    pf.orders.append(ts_order)
+    # Initial day sets highest_price
+    execute_orders(16.0, pf, 4)
+    assert ts_order in pf.orders
+    assert pf.shares == pytest.approx(100.0)
+
+    # Price moves up, highest_price increases
+    execute_orders(18.0, pf, 5)
+    assert ts_order.highest_price == pytest.approx(18.0)
+    assert pf.shares == pytest.approx(100.0)
+
+    # Price falls enough to trigger trailing stop
+    execute_orders(16.0, pf, 6)
+    assert pf.shares == pytest.approx(0.0)
+    assert pf.cash == pytest.approx(1600.0)
+    assert pf.orders == []
+


### PR DESCRIPTION
## Summary
- add comprehensive order execution test covering market, limit and trailing stop logic

## Testing
- `pytest tests/test_execution.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68597ec63fb0832c8fef9b35ed1117a0