### PR TITLE
Fix breakout strategy window logic

### DIFF
--- a/strategies/momentum_breakout_strategy.py
+++ b/strategies/momentum_breakout_strategy.py
@@ -25,10 +25,13 @@ def momentum_breakout_strategy(portfolio: Portfolio, date, price, day_index):
         state["in_position"] = False
 
     history = state["price_history"]
-    history.append(price)
 
     window = 10
+    # Use the previous `window` days to determine breakout/breakdown levels.
+    # We only append the current price after evaluating the conditions so that
+    # today's price does not influence the threshold calculations.
     if len(history) < window:
+        history.append(price)
         return
 
     recent_window = history[-window:]
@@ -58,3 +61,6 @@ def momentum_breakout_strategy(portfolio: Portfolio, date, price, day_index):
             state["last_sell_day"] = day_index
             if portfolio.shares - qty < 1e-6:
                 state["in_position"] = False
+
+    # Append the current price after evaluation so future windows include it
+    history.append(price)


### PR DESCRIPTION
## Summary
- fix momentum breakout strategy to evaluate breakout/breakdown against the prior 10 days
- add price after checking to maintain future windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685982707f68832ca8e2a5f058eeb07e