### PR TITLE
Add docstrings and type hints

### DIFF
--- a/optimization/report_pdf.py
+++ b/optimization/report_pdf.py
@@ -4,7 +4,8 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 
 
-def _plot_heatmap(pivot_df, title, pdf):
+def _plot_heatmap(pivot_df: pd.DataFrame, title: str, pdf: PdfPages) -> None:
+    """Plot a single heatmap page in the PDF."""
     fig, ax = plt.subplots()
     im = ax.imshow(pivot_df.values, cmap="viridis", aspect="auto", origin="lower")
     ax.set_xticks(range(len(pivot_df.columns)))
@@ -25,7 +26,7 @@ def _plot_heatmap(pivot_df, title, pdf):
     plt.close(fig)
 
 
-def create_pdf_report(best_by_year, output_dir):
+def create_pdf_report(best_by_year: dict[int, tuple], output_dir: str) -> str:
     """Create a PDF summary report for optimization results."""
     os.makedirs(output_dir, exist_ok=True)
     pdf_path = os.path.join(output_dir, "optimization_summary.pdf")

--- a/simulation/execution.py
+++ b/simulation/execution.py
@@ -3,20 +3,28 @@
 from stock_market_simulator.simulation.portfolio import Portfolio, Order
 
 
-def execute_orders(current_price, portfolio: Portfolio, day_index):
-    """
-    Executes any existing orders in the portfolio if their conditions are met.
-    Removes executed orders from the portfolio's order list.
+def execute_orders(current_price: float, portfolio: Portfolio, day_index: int) -> None:
+    """Execute any pending orders if their conditions are satisfied.
 
-    This version takes into account a fixed bid/ask spread stored in portfolio.spread,
-    which is now interpreted as a percentage.
+    Parameters
+    ----------
+    current_price:
+        The current market price of the security.
+    portfolio:
+        The :class:`Portfolio` whose orders should be processed.
+    day_index:
+        Integer index of the current simulation day.
 
-    For buy orders, the effective execution price is:
-      current_price * (1 + (spread/200))
-    For sell orders, it is:
-      current_price * (1 - (spread/200))
-
-    This adjustment applies half the spread percentage on either side.
+    Notes
+    -----
+    Executed orders are removed from ``portfolio.orders``. The function
+    accounts for ``portfolio.spread`` which is interpreted as a percentage
+    bid/ask spread and applied half on each side.
+    
+    Returns
+    -------
+    None
+        The portfolio is modified in place.
     """
     executed = []
     # Retrieve the fixed spread (default 0.0 if not set), interpreted as a percentage.

--- a/simulation/portfolio.py
+++ b/simulation/portfolio.py
@@ -1,28 +1,54 @@
 # stock_market_simulator/simulation/portfolio.py
 
 class Order:
-    def __init__(self, side, order_type,
-                 limit_price=None, stop_price=None,
-                 trail_percent=None, quantity=None):
+    """Represents a single order placed by a strategy."""
+
+    def __init__(self, side: str, order_type: str,
+                 limit_price: float | None = None, stop_price: float | None = None,
+                 trail_percent: float | None = None, quantity: float | None = None) -> None:
+        """Create a new order.
+
+        Parameters
+        ----------
+        side:
+            ``"buy"`` or ``"sell"``.
+        order_type:
+            The type of order (``"market"``, ``"limit"``, ``"stop"`` or ``"trailing_stop"``).
+        limit_price:
+            Price threshold for limit orders.
+        stop_price:
+            Price threshold for stop orders.
+        trail_percent:
+            Percent used for trailing stop orders.
+        quantity:
+            Quantity of shares for the order or ``None`` for all available.
+        """
+
         self.side = side
         self.order_type = order_type
         self.limit_price = limit_price
         self.stop_price = stop_price
         self.trail_percent = trail_percent
         self.quantity = quantity
-        self.highest_price = None
-        self.lowest_price = None
-        self.placement_day = None
+        self.highest_price: float | None = None
+        self.lowest_price: float | None = None
+        self.placement_day: int | None = None
 
 
 class Portfolio:
-    def __init__(self, initial_cash=10000.0):
-        self.cash = initial_cash
-        self.shares = 0.0
-        self.orders = []
-        self.initial_value = initial_cash
-        self.history = []
-        self.strategy_state = {}
+    """Simple portfolio tracking cash, shares and open orders."""
+
+    def __init__(self, initial_cash: float = 10000.0) -> None:
+        """Create a portfolio with a starting cash balance."""
+
+        self.cash: float = initial_cash
+        self.shares: float = 0.0
+        self.orders: list[Order] = []
+        self.initial_value: float = initial_cash
+        self.history: list[float] = []
+        self.strategy_state: dict = {}
 
     def total_value(self, price: float) -> float:
+        """Return the cash value of the portfolio at ``price``."""
+
         return self.cash + self.shares * price

--- a/strategies/base_strategies.py
+++ b/strategies/base_strategies.py
@@ -21,7 +21,7 @@ from stock_market_simulator.strategies.momentum_breakout_strategy import momentu
 from stock_market_simulator.strategies.rsi_strategy import rsi_strategy
 
 
-def buy_hold_strategy(portfolio: Portfolio, date, price, day_index):
+def buy_hold_strategy(portfolio: Portfolio, date, price: float, day_index: int) -> None:
     """
     Buy-and-hold strategy: Buy everything on the first day and then hold.
     """
@@ -32,7 +32,7 @@ def buy_hold_strategy(portfolio: Portfolio, date, price, day_index):
         portfolio.orders.append(order)
 
 
-def advanced_daytrading(portfolio: Portfolio, date, price, day_index):
+def advanced_daytrading(portfolio: Portfolio, date, price: float, day_index: int) -> None:
     """
     Advanced Day Trading Strategy.
 
@@ -107,21 +107,21 @@ def advanced_daytrading(portfolio: Portfolio, date, price, day_index):
             st["limit_buy_price"] = None
 
 
-def sma_trading_strategy(portfolio: Portfolio, date, price, day_index):
+def sma_trading_strategy(portfolio: Portfolio, date, price: float, day_index: int) -> None:
     """
     Delegates to the imported SMA Trading Strategy.
     """
     imported_sma_trading_strategy(portfolio, date, price, day_index)
 
 
-def momentum_breakout_strategy_wrapper(portfolio: Portfolio, date, price, day_index):
+def momentum_breakout_strategy_wrapper(portfolio: Portfolio, date, price: float, day_index: int) -> None:
     """
     Delegates to the imported Momentum Breakout Strategy.
     """
     momentum_breakout_strategy(portfolio, date, price, day_index)
 
 
-def rsi_strategy_wrapper(portfolio: Portfolio, date, price, day_index):
+def rsi_strategy_wrapper(portfolio: Portfolio, date, price: float, day_index: int) -> None:
     """
     Delegates to the imported RSI Strategy.
     """

--- a/strategies/momentum_breakout_strategy.py
+++ b/strategies/momentum_breakout_strategy.py
@@ -16,7 +16,20 @@ The strategy maintains its state (price history, last order days, and in_positio
 
 from stock_market_simulator.simulation.portfolio import Order, Portfolio
 
-def momentum_breakout_strategy(portfolio: Portfolio, date, price, day_index):
+def momentum_breakout_strategy(portfolio: Portfolio, date, price: float, day_index: int) -> None:
+    """Simple momentum breakout strategy.
+
+    Parameters
+    ----------
+    portfolio:
+        Portfolio instance tracking state and orders.
+    date:
+        Current date (unused but kept for API parity).
+    price:
+        Current closing price.
+    day_index:
+        Integer index of the current day in the simulation.
+    """
     state = portfolio.strategy_state
     if "price_history" not in state:
         state["price_history"] = []

--- a/strategies/rsi_strategy.py
+++ b/strategies/rsi_strategy.py
@@ -14,7 +14,7 @@ The strategy maintains its own price history and order timing in portfolio.strat
 
 from stock_market_simulator.simulation.portfolio import Order, Portfolio
 
-def compute_rsi(prices, period=14):
+def compute_rsi(prices: list[float], period: int = 14) -> float | None:
     """
     Compute the Relative Strength Index (RSI) for a list of prices.
 
@@ -41,7 +41,8 @@ def compute_rsi(prices, period=14):
     rsi = 100 - (100 / (1 + rs))
     return rsi
 
-def rsi_strategy(portfolio: Portfolio, date, price, day_index):
+def rsi_strategy(portfolio: Portfolio, date, price: float, day_index: int) -> None:
+    """Trading strategy based on the Relative Strength Index (RSI)."""
     state = portfolio.strategy_state
     if "price_history" not in state:
         state["price_history"] = []

--- a/strategies/sma_trading_strategy.py
+++ b/strategies/sma_trading_strategy.py
@@ -14,7 +14,8 @@ The strategy stores its price history and last order days in portfolio.strategy_
 
 from stock_market_simulator.simulation.portfolio import Order, Portfolio
 
-def sma_trading_strategy(portfolio: Portfolio, date, price, day_index):
+def sma_trading_strategy(portfolio: Portfolio, date, price: float, day_index: int) -> None:
+    """Trading strategy based on two simple moving averages."""
     state = portfolio.strategy_state
 
     if "sma_trading_history" not in state:


### PR DESCRIPTION
## Summary
- document simulation portfolio and add typing
- describe order execution workflow
- type annotate hybrid simulator functions
- annotate strategy helpers
- type hint optimization helpers
- document PDF heatmap helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859859959fc832cb1d8b6147e404362