### PR TITLE
Add config module for defaults

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,1 @@
+from src.stock_market_simulator.config import *  # noqa: F401,F403

--- a/data/data_fetcher.py
+++ b/data/data_fetcher.py
@@ -3,6 +3,8 @@
 import os
 from datetime import datetime
 
+from config import LOCAL_DATA_DIR
+
 import pandas as pd
 import yfinance as yf
 from filelock import FileLock
@@ -67,7 +69,11 @@ def _safe_download(ticker: str, start: str) -> pd.DataFrame:
     return df
 
 
-def load_historical_data(ticker: str, start_date="1980-01-01", local_data_dir="data/local_csv") -> pd.DataFrame:
+def load_historical_data(
+    ticker: str,
+    start_date="1980-01-01",
+    local_data_dir: str = LOCAL_DATA_DIR,
+) -> pd.DataFrame:
     """
     Load historical data for 'ticker' from a local CSV if available;
     otherwise download from Yahoo Finance and store a local copy.

--- a/gui/simulation_runner.py
+++ b/gui/simulation_runner.py
@@ -2,11 +2,21 @@
 
 import pandas as pd
 from datetime import datetime
-from stock_market_simulator.simulation.simulator import run_hybrid_multi_fund, intersect_all_indexes, \
-    HybridMultiFundPortfolio
+from config import DEFAULT_CASH
+from stock_market_simulator.simulation.simulator import (
+    run_hybrid_multi_fund,
+    intersect_all_indexes,
+    HybridMultiFundPortfolio,
+)
 
 
-def run_simulation(ticker_info_dict, dfs_dict, start_date_str, years, initial_cash=10000.0):
+def run_simulation(
+    ticker_info_dict,
+    dfs_dict,
+    start_date_str,
+    years,
+    initial_cash: float = DEFAULT_CASH,
+):
     """
     Run a single simulation for the given approach over the specified window.
 

--- a/gui/visualizer.py
+++ b/gui/visualizer.py
@@ -10,6 +10,8 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import pandas as pd
 import os
 
+from config import DEFAULT_CASH
+
 from stock_market_simulator.utils.config_parser import parse_config_file
 from stock_market_simulator.data.data_fetcher import load_historical_data
 from stock_market_simulator.gui.simulation_runner import run_simulation
@@ -61,7 +63,7 @@ class SimulatorVisualizer(tk.Tk):
         tk.Label(frame_params, text="Initial Cash:").grid(row=2, column=0, sticky=tk.W)
         self.entry_cash = tk.Entry(frame_params)
         self.entry_cash.grid(row=2, column=1, padx=5)
-        self.entry_cash.insert(0, "10000")
+        self.entry_cash.insert(0, str(DEFAULT_CASH))
 
         btn_run = tk.Button(frame_params, text="Run Simulation", command=self.run_simulation)
         btn_run.grid(row=3, column=0, columnspan=2, pady=10)

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 from io import StringIO
 from collections import defaultdict
 
+from config import DEFAULT_CASH, REPORTS_DIR
 from stock_market_simulator.utils.config_parser import parse_config_file
 from stock_market_simulator.data.data_fetcher import load_historical_data
 from stock_market_simulator.simulation.simulator import run_configured_sweep
@@ -17,7 +18,7 @@ def run_approach(aname, ticker_strat_dict, years, stepsize):
     """Run one simulation approach in a separate process."""
     needed = set(ticker_strat_dict.keys())
     all_dfs = {tk: load_historical_data(tk) for tk in needed}
-    return run_configured_sweep(all_dfs, aname, ticker_strat_dict, years, stepsize, 10000.0)
+    return run_configured_sweep(all_dfs, aname, ticker_strat_dict, years, stepsize, DEFAULT_CASH)
 
 def generate_boxplots(approach_data, output_dir, out_name):
     """
@@ -104,7 +105,7 @@ def main():
     out_name = sys.argv[2]
     workers = int(sys.argv[3]) if len(sys.argv) >= 4 else (os.cpu_count() or 1)
 
-    base_dir = "reports"
+    base_dir = REPORTS_DIR
     out_dir = os.path.join(base_dir, out_name)
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)

--- a/optimization/parameter_sweeper.py
+++ b/optimization/parameter_sweeper.py
@@ -5,6 +5,7 @@ import concurrent.futures
 import os
 import numpy as np
 import pandas as pd
+from config import DEFAULT_CASH
 from tqdm import tqdm
 from stock_market_simulator.simulation.simulator import (
     run_hybrid_multi_fund,
@@ -27,8 +28,14 @@ def _init_worker(dfs_dict, ticker_info_dict):
     _TICKER_INFO_DICT = ticker_info_dict
 
 
-def run_advanced_daytrading_simulation(ticker_info_dict, dfs_dict, start_date, years, initial_cash=10000.0,
-                                       return_history=False):
+def run_advanced_daytrading_simulation(
+    ticker_info_dict,
+    dfs_dict,
+    start_date,
+    years,
+    initial_cash: float = DEFAULT_CASH,
+    return_history=False,
+):
     """
     Runs a simulation for the given advanced_daytrading approach over the specified window.
 
@@ -136,9 +143,17 @@ def candidate_worker(args):
         return (start_date, years, ts_pct, lb_discount, pl_days, None)
 
 
-def full_parameter_sweep_advanced_daytrading(ticker_info_dict, dfs_dict, candidate_years, initial_cash,
-                                             trailing_stop_values, limit_buy_discount_values, pending_limit_days_values,
-                                             metric_selector=metric_final, max_workers=None):
+def full_parameter_sweep_advanced_daytrading(
+    ticker_info_dict,
+    dfs_dict,
+    candidate_years,
+    initial_cash: float,
+    trailing_stop_values,
+    limit_buy_discount_values,
+    pending_limit_days_values,
+    metric_selector=metric_final,
+    max_workers=None,
+):
     """
     Performs a grid search over simulation parameters and advanced_daytrading strategy parameters.
 
@@ -191,9 +206,17 @@ def full_parameter_sweep_advanced_daytrading(ticker_info_dict, dfs_dict, candida
     return results
 
 
-def optimize_full_advanced_daytrading(ticker_info_dict, dfs_dict, candidate_years, initial_cash,
-                                      trailing_stop_values, limit_buy_discount_values, pending_limit_days_values,
-                                      metric_selector=metric_final, max_workers=None):
+def optimize_full_advanced_daytrading(
+    ticker_info_dict,
+    dfs_dict,
+    candidate_years,
+    initial_cash: float,
+    trailing_stop_values,
+    limit_buy_discount_values,
+    pending_limit_days_values,
+    metric_selector=metric_final,
+    max_workers=None,
+):
     """
     Optimizes the advanced_daytrading strategy parameters along with the simulation window (years)
     by performing a grid search over:

--- a/run_optimization.py
+++ b/run_optimization.py
@@ -5,6 +5,8 @@ import sys
 import pandas as pd
 import multiprocessing
 
+from config import DEFAULT_CASH, REPORTS_DIR
+
 from stock_market_simulator.data.data_fetcher import load_historical_data
 from stock_market_simulator.strategies.base_strategies import STRATEGY_MAP
 from stock_market_simulator.optimization.parameter_sweeper import (
@@ -19,7 +21,7 @@ def main():
     if len(sys.argv) >= 2:
         output_name = sys.argv[1]
 
-    out_dir = os.path.join("reports", output_name)
+    out_dir = os.path.join(REPORTS_DIR, output_name)
     os.makedirs(out_dir, exist_ok=True)
 
     # Specify the ticker and load historical data.
@@ -44,7 +46,7 @@ def main():
     trailing_stop_values = [8.0, 9.0, 10.0, 11.0, 12.0]
     limit_buy_discount_values = [3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0]
     pending_limit_days_values = [40, 45,  50, 55, 60]
-    initial_cash = 10000.0
+    initial_cash = DEFAULT_CASH
 
     # For example, optimize based on CAGR.
     from stock_market_simulator.optimization.parameter_sweeper import optimize_full_advanced_daytrading, metric_cagr

--- a/simulation/portfolio.py
+++ b/simulation/portfolio.py
@@ -15,8 +15,11 @@ class Order:
         self.placement_day = None
 
 
+from config import DEFAULT_CASH
+
+
 class Portfolio:
-    def __init__(self, initial_cash=10000.0):
+    def __init__(self, initial_cash: float = DEFAULT_CASH):
         self.cash = initial_cash
         self.shares = 0.0
         self.orders = []

--- a/simulation/simulator.py
+++ b/simulation/simulator.py
@@ -1,6 +1,7 @@
 # stock_market_simulator/simulation/simulator.py
 
 import pandas as pd
+from config import DEFAULT_CASH
 from stock_market_simulator.simulation.portfolio import Portfolio
 from stock_market_simulator.simulation.execution import execute_orders
 
@@ -9,7 +10,7 @@ class HybridMultiFundPortfolio:
     Combines multiple sub-portfolios (one per ticker),
     each with its own strategy and slice of the total cash.
     """
-    def __init__(self, ticker_info_dict: dict, initial_cash=10000.0):
+    def __init__(self, ticker_info_dict: dict, initial_cash: float = DEFAULT_CASH):
         # ticker_info_dict is a mapping: ticker -> { "strategy": strategy_func, "spread": spread (as percentage),
         #     optionally "trailing_stop_pct", "limit_buy_discount_pct", "pending_limit_days" }
         self.initial_cash = initial_cash
@@ -107,7 +108,14 @@ def find_monthly_starts_first_open(common_idx):
     monthly_starts = [by_ym[k] for k in keys]
     return monthly_starts
 
-def run_configured_sweep(dfs_dict, approach_name, ticker_info_dict, years, stepsize, initial_cash=10000.0):
+def run_configured_sweep(
+    dfs_dict,
+    approach_name,
+    ticker_info_dict,
+    years,
+    stepsize,
+    initial_cash: float = DEFAULT_CASH,
+):
     """
     Runs multiple subrange simulations, each lasting `years` years,
     and computes performance metrics.

--- a/src/stock_market_simulator/config.py
+++ b/src/stock_market_simulator/config.py
@@ -1,0 +1,28 @@
+import os
+import logging
+
+# Default starting cash for simulations
+DEFAULT_CASH = 10000.0
+
+# Directories for cached data and reports
+LOCAL_DATA_DIR = os.getenv("SIM_DATA_DIR", "data/local_csv")
+GUI_DATA_DIR = os.getenv("SIM_GUI_DATA_DIR", "gui/data/local_csv")
+REPORTS_DIR = os.getenv("SIM_REPORTS_DIR", "reports")
+
+
+def init_logging(level: str | int | None = None) -> None:
+    """Configure basic logging.
+
+    Parameters
+    ----------
+    level:
+        Logging level name or integer. If ``None``, the ``SIM_LOG_LEVEL``
+        environment variable is checked and defaults to ``INFO``.
+    """
+    if level is None:
+        env_level = os.getenv("SIM_LOG_LEVEL", "INFO")
+        try:
+            level = int(env_level)
+        except ValueError:
+            level = getattr(logging, env_level.upper(), logging.INFO)
+    logging.basicConfig(level=level, format="[%(levelname)s] %(message)s")

--- a/utils/cleanup_cache.py
+++ b/utils/cleanup_cache.py
@@ -14,6 +14,8 @@ import csv
 import os
 from typing import Iterable
 
+from config import LOCAL_DATA_DIR, GUI_DATA_DIR
+
 EXPECTED_HEADER = ["Date", "Open", "High", "Low", "Close", "Volume"]
 
 
@@ -53,7 +55,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    for directory in ("data/local_csv", "gui/data/local_csv"):
+    for directory in (LOCAL_DATA_DIR, GUI_DATA_DIR):
         _process_dir(directory, delete=args.delete)
 
 


### PR DESCRIPTION
## Summary
- add `src/stock_market_simulator/config.py` with default cash, directories and logging helper
- expose config through `config.py`
- replace literals with imports from `config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685985bde6d8832cb32f4d4201e0b701